### PR TITLE
docs: update to install windows c++ build tools for siphash-cffi package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,10 @@ Windows
 - Install `Python 3.7`_
 - Install `Git`_
 - ``git clone https://github.com/altendky/pm``
+- Install `Build Tools for Visual Studio 2019`_
+
+  - Select "C++ build tools" option
+
 - ``cd pm``
 - ``git submodule update --init``
 - ``py boots.py ensure``
@@ -54,6 +58,7 @@ To launch PM run ``venv\Scripts\epcpm.exe``.
 
 .. _`Python 3.7`: https://www.python.org/downloads/
 .. _`Git`: https://git-scm.com/download
+.. _`Build Tools for Visual Studio 2019`: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019
 
 Linux
 =====

--- a/README.rst
+++ b/README.rst
@@ -40,10 +40,6 @@ Windows
 - Install `Python 3.7`_
 - Install `Git`_
 - ``git clone https://github.com/altendky/pm``
-- Install `Build Tools for Visual Studio 2019`_
-
-  - Select "C++ build tools" option
-
 - ``cd pm``
 - ``git submodule update --init``
 - ``py boots.py ensure``
@@ -58,7 +54,6 @@ To launch PM run ``venv\Scripts\epcpm.exe``.
 
 .. _`Python 3.7`: https://www.python.org/downloads/
 .. _`Git`: https://git-scm.com/download
-.. _`Build Tools for Visual Studio 2019`: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019
 
 Linux
 =====

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,8 @@
 --requirement pre.in
 
+--extra-index-url http://fstab.net/pypi/simple
+--trusted-host fstab.net
+
 attrs==20.2.0
 click==7.1.2
 epyqlib==2020.1.4

--- a/requirements/base.linux.txt
+++ b/requirements/base.linux.txt
@@ -4,91 +4,94 @@
 #
 #    python boots.py lock
 #
+--extra-index-url http://fstab.net/pypi/simple
+--trusted-host fstab.net
+
 -e git+https://github.com/epcpower/sunspec-demo@19581317ae2fd136b5df229d824f81a17da52c58#egg=epcsunspecdemo  # via -r /home/vsts/work/1/s/work/requirements/base.in, epyqlib
 -e file:sub/epyqlib#egg=epyqlib  # via -r /home/vsts/work/1/s/work/requirements/base.in
 -e git+https://github.com/altendky/pycparser@b19d2b7cb78bccc89ef187c1c4eb5db0fdd3bbf9#egg=pycparser  # via -r /home/vsts/work/1/s/work/requirements/base.in, cffi
 -e git+https://github.com/pyinstaller/PyInstaller@46286a1f455d8e0837f7c2b9e1bbdff1ef858f0f#egg=PyInstaller  # via -r /home/vsts/work/1/s/work/requirements/base.in
 -e git+https://github.com/altendky/pysunspec@f197baa9c373ff93b13bff22a1ca0368aa89b305#egg=pysunspec  # via -r /home/vsts/work/1/s/work/requirements/base.in, epcsunspecdemo
-aenum==2.2.4              # via python-can
-alqtendpy==0.0.4          # via epyqlib
+aenum==3.0.0              # via python-can
+alqtendpy==0.1.1          # via epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via pyinstaller
 appdirs==1.4.4            # via virtualenv
-arrow==0.16.0             # via epyqlib
+arrow==1.0.3              # via epyqlib
 attrs==20.2.0             # via -r /home/vsts/work/1/s/work/requirements/base.in, alqtendpy, altendpy, automat, canmatrix, epcsunspecdemo, graham, twisted
 automat==20.2.0           # via twisted
-bitstruct==8.11.0         # via canmatrix, epyqlib
-bleach==3.1.5             # via readme-renderer
+bitstruct==8.11.1         # via canmatrix, epyqlib
+bleach==3.3.0             # via readme-renderer
 canmatrix==0.9.1          # via -r /home/vsts/work/1/s/work/requirements/base.in, epyqlib
-certifi==2020.6.20        # via requests
-cffi==1.14.2              # via cryptography, siphash-cffi
+certifi==2020.12.5        # via requests
+cffi==1.14.5              # via cryptography, siphash-cffi
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r /home/vsts/work/1/s/work/requirements/base.in, alqtendpy, canmatrix, epcsunspecdemo, epyqlib, pip-tools, romp
 constantly==15.1.0        # via twisted
-cryptography==3.1         # via secretstorage
+cryptography==3.4.7       # via secretstorage
 distlib==0.3.1            # via virtualenv
-docutils==0.16            # via readme-renderer
+docutils==0.17.1          # via readme-renderer
 et-xmlfile==1.0.1         # via openpyxl
 filelock==3.0.12          # via virtualenv
 future==0.18.2            # via canmatrix
-gitdb==4.0.5              # via gitpython
-gitpython==3.1.8          # via epyqlib
+gitdb==4.0.7              # via gitpython
+gitpython==3.1.14         # via epyqlib
 graham==0.1.11            # via -r /home/vsts/work/1/s/work/requirements/base.in, epyqlib
-hyperlink==20.0.1         # via twisted
+hyperlink==21.0.0         # via twisted
 idna==2.7                 # via hyperlink, requests
-importlib-metadata==1.7.0  # via keyring, pint, pluggy, twine, virtualenv
-incremental==17.5.0       # via twisted
+importlib-metadata==4.0.0  # via keyring, pint, pluggy, twine, virtualenv
+incremental==21.3.0       # via twisted
 jdcal==1.4.1              # via openpyxl
-jeepney==0.4.3            # via keyring, secretstorage
+jeepney==0.6.0            # via keyring, secretstorage
 jinja2==2.10.1            # via -r /home/vsts/work/1/s/work/requirements/base.in, altendpy
-keyring==21.4.0           # via twine
+keyring==23.0.1           # via twine
 lxml==4.3.0               # via -r /home/vsts/work/1/s/work/requirements/base.in, python-docx, xmldiff
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
-natsort==7.0.1            # via epyqlib
+natsort==7.1.1            # via epyqlib
 openpyxl==2.5.12          # via -r /home/vsts/work/1/s/work/requirements/base.in
-packaging==20.4           # via bleach, pint
+packaging==20.9           # via bleach, pint
 pathlib2==2.3.5           # via canmatrix
-pint==0.15                # via epyqlib
+pint==0.17                # via epyqlib
 pip-tools==5.1.0          # via -r /home/vsts/work/1/s/work/requirements/pre.in
-pkginfo==1.5.0.1          # via twine
+pkginfo==1.7.0            # via twine
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
-pyelftools==0.26          # via epyqlib
-pygments==2.6.1           # via readme-renderer
-pyhamcrest==2.0.2         # via twisted
+py==1.10.0                # via tox
+pyelftools==0.27          # via epyqlib
+pygments==2.8.1           # via readme-renderer
 pyparsing==2.4.7          # via packaging
 pyqt5-sip==12.8.1         # via pyqt5
 pyqt5==5.13.0             # via -r /home/vsts/work/1/s/work/requirements/base.in, alqtendpy, epyqlib
 pyserial==3.4             # via -r /home/vsts/work/1/s/work/requirements/base.in, pysunspec
-python-can==3.3.3         # via epyqlib
+python-can==3.3.4         # via epyqlib
 python-dateutil==2.8.1    # via arrow
 python-docx==0.8.10       # via epyqlib
-python-dotenv==0.14.0     # via epyqlib
+python-dotenv==0.17.0     # via epyqlib
 qt5reactor==0.6.3         # via epyqlib
-qtawesome==0.7.2          # via epyqlib
+qtawesome==1.0.2          # via epyqlib
 qtpy==1.9.0               # via qtawesome
-readme-renderer==26.0     # via twine
+readme-renderer==29.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.20.0          # via -r /home/vsts/work/1/s/work/requirements/base.in, requests-toolbelt, romp, twine
 romp==2020.3              # via -r /home/vsts/work/1/s/work/requirements/pre.in
-secretstorage==3.1.2      # via keyring
+secretstorage==3.3.1      # via keyring
 siphash-cffi==0.1.4       # via epyqlib
-six==1.15.0               # via automat, bleach, cryptography, packaging, pathlib2, pip-tools, python-dateutil, qtawesome, readme-renderer, virtualenv, xmldiff
-smmap==3.0.4              # via gitdb
+six==1.15.0               # via automat, bleach, pathlib2, pip-tools, python-dateutil, readme-renderer, virtualenv, xmldiff
+smmap==4.0.0              # via gitdb
 toolz==0.9.0              # via -r /home/vsts/work/1/s/work/requirements/base.in, epcsunspecdemo
 tox==2.8.2                # via -r /home/vsts/work/1/s/work/requirements/base.in
-tqdm==4.48.2              # via epcsunspecdemo, twine
+tqdm==4.60.0              # via epcsunspecdemo, twine
 twine==3.1.1              # via -r /home/vsts/work/1/s/work/requirements/pre.in
-twisted==20.3.0           # via epyqlib, qt5reactor
+twisted==21.2.0           # via epyqlib, qt5reactor
+typing-extensions==3.7.4.3  # via arrow, importlib-metadata
 urllib3==1.24.3           # via requests
-virtualenv==20.0.31       # via tox
+virtualenv==20.4.3        # via tox
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r /home/vsts/work/1/s/work/requirements/pre.in
 wrapt==1.12.1             # via python-can
 xmldiff==2.2              # via -r /home/vsts/work/1/s/work/requirements/base.in
-zipp==3.1.0               # via importlib-metadata
-zope.interface==5.1.0     # via twisted
+zipp==3.4.1               # via importlib-metadata
+zope.interface==5.4.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/base.macos.txt
+++ b/requirements/base.macos.txt
@@ -4,89 +4,92 @@
 #
 #    python boots.py lock
 #
+--extra-index-url http://fstab.net/pypi/simple
+--trusted-host fstab.net
+
 -e git+https://github.com/epcpower/sunspec-demo@19581317ae2fd136b5df229d824f81a17da52c58#egg=epcsunspecdemo  # via -r /Users/runner/work/1/s/work/requirements/base.in, epyqlib
 -e file:sub/epyqlib#egg=epyqlib  # via -r /Users/runner/work/1/s/work/requirements/base.in
 -e git+https://github.com/altendky/pycparser@b19d2b7cb78bccc89ef187c1c4eb5db0fdd3bbf9#egg=pycparser  # via -r /Users/runner/work/1/s/work/requirements/base.in, cffi
 -e git+https://github.com/pyinstaller/PyInstaller@46286a1f455d8e0837f7c2b9e1bbdff1ef858f0f#egg=PyInstaller  # via -r /Users/runner/work/1/s/work/requirements/base.in
 -e git+https://github.com/altendky/pysunspec@f197baa9c373ff93b13bff22a1ca0368aa89b305#egg=pysunspec  # via -r /Users/runner/work/1/s/work/requirements/base.in, epcsunspecdemo
-aenum==2.2.4              # via python-can
-alqtendpy==0.0.4          # via epyqlib
+aenum==3.0.0              # via python-can
+alqtendpy==0.1.1          # via epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via macholib, pyinstaller
 appdirs==1.4.4            # via virtualenv
-arrow==0.16.0             # via epyqlib
+arrow==1.0.3              # via epyqlib
 attrs==20.2.0             # via -r /Users/runner/work/1/s/work/requirements/base.in, alqtendpy, altendpy, automat, canmatrix, epcsunspecdemo, graham, twisted
 automat==20.2.0           # via twisted
-bitstruct==8.11.0         # via canmatrix, epyqlib
-bleach==3.1.5             # via readme-renderer
+bitstruct==8.11.1         # via canmatrix, epyqlib
+bleach==3.3.0             # via readme-renderer
 canmatrix==0.9.1          # via -r /Users/runner/work/1/s/work/requirements/base.in, epyqlib
-certifi==2020.6.20        # via requests
-cffi==1.14.2              # via siphash-cffi
+certifi==2020.12.5        # via requests
+cffi==1.14.5              # via siphash-cffi
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r /Users/runner/work/1/s/work/requirements/base.in, alqtendpy, canmatrix, epcsunspecdemo, epyqlib, pip-tools, romp
 constantly==15.1.0        # via twisted
 distlib==0.3.1            # via virtualenv
-docutils==0.16            # via readme-renderer
+docutils==0.17.1          # via readme-renderer
 et-xmlfile==1.0.1         # via openpyxl
 filelock==3.0.12          # via virtualenv
 future==0.18.2            # via canmatrix
-gitdb==4.0.5              # via gitpython
-gitpython==3.1.8          # via epyqlib
+gitdb==4.0.7              # via gitpython
+gitpython==3.1.14         # via epyqlib
 graham==0.1.11            # via -r /Users/runner/work/1/s/work/requirements/base.in, epyqlib
-hyperlink==20.0.1         # via twisted
+hyperlink==21.0.0         # via twisted
 idna==2.7                 # via hyperlink, requests
-importlib-metadata==1.7.0  # via keyring, pint, pluggy, twine, virtualenv
-incremental==17.5.0       # via twisted
+importlib-metadata==4.0.0  # via keyring, pint, pluggy, twine, virtualenv
+incremental==21.3.0       # via twisted
 jdcal==1.4.1              # via openpyxl
 jinja2==2.10.1            # via -r /Users/runner/work/1/s/work/requirements/base.in, altendpy
-keyring==21.4.0           # via twine
+keyring==23.0.1           # via twine
 lxml==4.3.0               # via -r /Users/runner/work/1/s/work/requirements/base.in, python-docx, xmldiff
 macholib==1.14            # via pyinstaller
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
-natsort==7.0.1            # via epyqlib
+natsort==7.1.1            # via epyqlib
 openpyxl==2.5.12          # via -r /Users/runner/work/1/s/work/requirements/base.in
-packaging==20.4           # via bleach, pint
+packaging==20.9           # via bleach, pint
 pathlib2==2.3.5           # via canmatrix
-pint==0.15                # via epyqlib
+pint==0.17                # via epyqlib
 pip-tools==5.1.0          # via -r /Users/runner/work/1/s/work/requirements/pre.in
-pkginfo==1.5.0.1          # via twine
+pkginfo==1.7.0            # via twine
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
-pyelftools==0.26          # via epyqlib
-pygments==2.6.1           # via readme-renderer
-pyhamcrest==2.0.2         # via twisted
+py==1.10.0                # via tox
+pyelftools==0.27          # via epyqlib
+pygments==2.8.1           # via readme-renderer
 pyparsing==2.4.7          # via packaging
 pyqt5-sip==12.8.1         # via pyqt5
 pyqt5==5.13.0             # via -r /Users/runner/work/1/s/work/requirements/base.in, alqtendpy, epyqlib
 pyserial==3.4             # via -r /Users/runner/work/1/s/work/requirements/base.in, pysunspec
-python-can==3.3.3         # via epyqlib
+python-can==3.3.4         # via epyqlib
 python-dateutil==2.8.1    # via arrow
 python-docx==0.8.10       # via epyqlib
-python-dotenv==0.14.0     # via epyqlib
+python-dotenv==0.17.0     # via epyqlib
 qt5reactor==0.6.3         # via epyqlib
-qtawesome==0.7.2          # via epyqlib
+qtawesome==1.0.2          # via epyqlib
 qtpy==1.9.0               # via qtawesome
-readme-renderer==26.0     # via twine
+readme-renderer==29.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.20.0          # via -r /Users/runner/work/1/s/work/requirements/base.in, requests-toolbelt, romp, twine
 romp==2020.3              # via -r /Users/runner/work/1/s/work/requirements/pre.in
 siphash-cffi==0.1.4       # via epyqlib
-six==1.15.0               # via automat, bleach, packaging, pathlib2, pip-tools, python-dateutil, qtawesome, readme-renderer, virtualenv, xmldiff
-smmap==3.0.4              # via gitdb
+six==1.15.0               # via automat, bleach, pathlib2, pip-tools, python-dateutil, readme-renderer, virtualenv, xmldiff
+smmap==4.0.0              # via gitdb
 toolz==0.9.0              # via -r /Users/runner/work/1/s/work/requirements/base.in, epcsunspecdemo
 tox==2.8.2                # via -r /Users/runner/work/1/s/work/requirements/base.in
-tqdm==4.48.2              # via epcsunspecdemo, twine
+tqdm==4.60.0              # via epcsunspecdemo, twine
 twine==3.1.1              # via -r /Users/runner/work/1/s/work/requirements/pre.in
-twisted==20.3.0           # via epyqlib, qt5reactor
+twisted==21.2.0           # via epyqlib, qt5reactor
+typing-extensions==3.7.4.3  # via arrow, importlib-metadata
 urllib3==1.24.3           # via requests
-virtualenv==20.0.31       # via tox
+virtualenv==20.4.3        # via tox
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r /Users/runner/work/1/s/work/requirements/pre.in
 wrapt==1.12.1             # via python-can
 xmldiff==2.2              # via -r /Users/runner/work/1/s/work/requirements/base.in
-zipp==3.1.0               # via importlib-metadata
-zope.interface==5.1.0     # via twisted
+zipp==3.4.1               # via importlib-metadata
+zope.interface==5.4.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/base.windows.txt
+++ b/requirements/base.windows.txt
@@ -4,91 +4,95 @@
 #
 #    python boots.py lock
 #
+--extra-index-url http://fstab.net/pypi/simple
+--trusted-host fstab.net
+
 -e git+https://github.com/epcpower/sunspec-demo@19581317ae2fd136b5df229d824f81a17da52c58#egg=epcsunspecdemo  # via -r D:\a\1\s\work\requirements\base.in, epyqlib
 -e file:sub/epyqlib#egg=epyqlib  # via -r D:\a\1\s\work\requirements\base.in
 -e git+https://github.com/altendky/pycparser@b19d2b7cb78bccc89ef187c1c4eb5db0fdd3bbf9#egg=pycparser  # via -r D:\a\1\s\work\requirements\base.in, cffi
 -e git+https://github.com/pyinstaller/PyInstaller@46286a1f455d8e0837f7c2b9e1bbdff1ef858f0f#egg=PyInstaller  # via -r D:\a\1\s\work\requirements\base.in
 -e git+https://github.com/altendky/pysunspec@f197baa9c373ff93b13bff22a1ca0368aa89b305#egg=pysunspec  # via -r D:\a\1\s\work\requirements\base.in, epcsunspecdemo
-aenum==2.2.4              # via python-can
-alqtendpy==0.0.4          # via epyqlib
+aenum==3.0.0              # via python-can
+alqtendpy==0.1.1          # via epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via pyinstaller
 appdirs==1.4.4            # via virtualenv
-arrow==0.16.0             # via epyqlib
+arrow==1.0.3              # via epyqlib
 attrs==20.2.0             # via -r D:\a\1\s\work\requirements\base.in, alqtendpy, altendpy, automat, canmatrix, epcsunspecdemo, graham, twisted
 automat==20.2.0           # via twisted
-bitstruct==8.11.0         # via canmatrix, epyqlib
-bleach==3.1.5             # via readme-renderer
+bitstruct==8.11.1         # via canmatrix, epyqlib
+bleach==3.3.0             # via readme-renderer
 canmatrix==0.9.1          # via -r D:\a\1\s\work\requirements\base.in, epyqlib
-certifi==2020.6.20        # via requests
-cffi==1.14.2              # via siphash-cffi
+certifi==2020.12.5        # via requests
+cffi==1.14.5              # via siphash-cffi
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r D:\a\1\s\work\requirements\base.in, alqtendpy, canmatrix, epcsunspecdemo, epyqlib, pip-tools, romp
 constantly==15.1.0        # via twisted
 distlib==0.3.1            # via virtualenv
-docutils==0.16            # via readme-renderer
+docutils==0.17.1          # via readme-renderer
 et-xmlfile==1.0.1         # via openpyxl
 filelock==3.0.12          # via virtualenv
 future==0.18.2            # via canmatrix, pefile
-gitdb==4.0.5              # via gitpython
-gitpython==3.1.8          # via epyqlib
+gitdb==4.0.7              # via gitpython
+gitpython==3.1.14         # via epyqlib
 graham==0.1.11            # via -r D:\a\1\s\work\requirements\base.in, epyqlib
-hyperlink==20.0.1         # via twisted
+hyperlink==21.0.0         # via twisted
 idna==2.7                 # via hyperlink, requests
-importlib-metadata==1.7.0  # via keyring, pint, pluggy, twine, virtualenv
-incremental==17.5.0       # via twisted
+importlib-metadata==4.0.0  # via keyring, pint, pluggy, twine, virtualenv
+incremental==21.3.0       # via twisted
 jdcal==1.4.1              # via openpyxl
 jinja2==2.10.1            # via -r D:\a\1\s\work\requirements\base.in, altendpy
-keyring==21.4.0           # via twine
+keyring==23.0.1           # via twine
 lxml==4.3.0               # via -r D:\a\1\s\work\requirements\base.in, python-docx, xmldiff
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
-natsort==7.0.1            # via epyqlib
+natsort==7.1.1            # via epyqlib
 openpyxl==2.5.12          # via -r D:\a\1\s\work\requirements\base.in
-packaging==20.4           # via bleach, pint
+packaging==20.9           # via bleach, pint
 pathlib2==2.3.5           # via canmatrix
 pefile==2019.4.18         # via pyinstaller
-pint==0.15                # via epyqlib
+pint==0.17                # via epyqlib
 pip-tools==5.1.0          # via -r D:\a\1\s\work\requirements\pre.in
-pkginfo==1.5.0.1          # via twine
+pkginfo==1.7.0            # via twine
 pluggy==0.13.1            # via tox
-py==1.9.0                 # via tox
-pyelftools==0.26          # via epyqlib
-pygments==2.6.1           # via readme-renderer
-pyhamcrest==2.0.2         # via twisted
+py==1.10.0                # via tox
+pyelftools==0.27          # via epyqlib
+pygments==2.8.1           # via readme-renderer
 pyparsing==2.4.7          # via packaging
 pyqt5-sip==12.8.1         # via pyqt5
 pyqt5==5.13.0             # via -r D:\a\1\s\work\requirements\base.in, alqtendpy, epyqlib
 pyserial==3.4             # via -r D:\a\1\s\work\requirements\base.in, pysunspec
-python-can==3.3.3         # via epyqlib
+python-can==3.3.4         # via epyqlib
 python-dateutil==2.8.1    # via arrow
 python-docx==0.8.10       # via epyqlib
-python-dotenv==0.14.0     # via epyqlib
+python-dotenv==0.17.0     # via epyqlib
 pywin32-ctypes==0.2.0     # via keyring, pyinstaller
 qt5reactor==0.6.3         # via epyqlib
-qtawesome==0.7.2          # via epyqlib
+qtawesome==1.0.2          # via epyqlib
 qtpy==1.9.0               # via qtawesome
-readme-renderer==26.0     # via twine
+readme-renderer==29.0     # via twine
 requests-toolbelt==0.9.1  # via twine
 requests==2.20.0          # via -r D:\a\1\s\work\requirements\base.in, requests-toolbelt, romp, twine
 romp==2020.3              # via -r D:\a\1\s\work\requirements\pre.in
 siphash-cffi==0.1.4       # via epyqlib
-six==1.15.0               # via automat, bleach, packaging, pathlib2, pip-tools, python-dateutil, qtawesome, readme-renderer, virtualenv, xmldiff
-smmap==3.0.4              # via gitdb
+six==1.15.0               # via automat, bleach, pathlib2, pip-tools, python-dateutil, readme-renderer, virtualenv, xmldiff
+smmap==4.0.0              # via gitdb
 toolz==0.9.0              # via -r D:\a\1\s\work\requirements\base.in, epcsunspecdemo
 tox==2.8.2                # via -r D:\a\1\s\work\requirements\base.in
-tqdm==4.48.2              # via epcsunspecdemo, twine
+tqdm==4.60.0              # via epcsunspecdemo, twine
 twine==3.1.1              # via -r D:\a\1\s\work\requirements\pre.in
-twisted==20.3.0           # via epyqlib, qt5reactor
+twisted-iocpsupport==1.0.1  # via twisted
+twisted==21.2.0           # via epyqlib, qt5reactor
+typing-extensions==3.7.4.3  # via arrow, importlib-metadata
 urllib3==1.24.3           # via requests
-virtualenv==20.0.31       # via tox
+virtualenv==20.4.3        # via tox
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r D:\a\1\s\work\requirements\pre.in
-windows-curses==2.1.0     # via python-can
+windows-curses==2.2.0     # via python-can
 wrapt==1.12.1             # via python-can
 xmldiff==2.2              # via -r D:\a\1\s\work\requirements\base.in
-zipp==3.1.0               # via importlib-metadata
-zope.interface==5.1.0     # via twisted
+zipp==3.4.1               # via importlib-metadata
+zope.interface==5.4.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pre.linux.txt
+++ b/requirements/pre.linux.txt
@@ -4,35 +4,36 @@
 #
 #    python boots.py lock
 #
-bleach==3.1.5             # via readme-renderer
-certifi==2020.6.20        # via requests
-cffi==1.14.2              # via cryptography
-chardet==3.0.4            # via requests
+bleach==3.3.0             # via readme-renderer
+certifi==2020.12.5        # via requests
+cffi==1.14.5              # via cryptography
+chardet==4.0.0            # via requests
 click==7.1.2              # via pip-tools, romp
-cryptography==3.1         # via secretstorage
-docutils==0.16            # via readme-renderer
+cryptography==3.4.7       # via secretstorage
+docutils==0.17.1          # via readme-renderer
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via keyring, twine
-jeepney==0.4.3            # via keyring, secretstorage
-keyring==21.4.0           # via twine
-packaging==20.4           # via bleach
+importlib-metadata==4.0.0  # via keyring, twine
+jeepney==0.6.0            # via keyring, secretstorage
+keyring==23.0.1           # via twine
+packaging==20.9           # via bleach
 pip-tools==5.1.0          # via -r /home/vsts/work/1/s/work/requirements/pre.in
-pkginfo==1.5.0.1          # via twine
+pkginfo==1.7.0            # via twine
 pycparser==2.20           # via cffi
-pygments==2.6.1           # via readme-renderer
+pygments==2.8.1           # via readme-renderer
 pyparsing==2.4.7          # via packaging
-readme-renderer==26.0     # via twine
+readme-renderer==29.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.24.0          # via requests-toolbelt, romp, twine
+requests==2.25.1          # via requests-toolbelt, romp, twine
 romp==2020.3              # via -r /home/vsts/work/1/s/work/requirements/pre.in
-secretstorage==3.1.2      # via keyring
-six==1.15.0               # via bleach, cryptography, packaging, pip-tools, readme-renderer
-tqdm==4.48.2              # via twine
+secretstorage==3.3.1      # via keyring
+six==1.15.0               # via bleach, pip-tools, readme-renderer
+tqdm==4.60.0              # via twine
 twine==3.1.1              # via -r /home/vsts/work/1/s/work/requirements/pre.in
-urllib3==1.25.10          # via requests
+typing-extensions==3.7.4.3  # via importlib-metadata
+urllib3==1.26.4           # via requests
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r /home/vsts/work/1/s/work/requirements/pre.in
-zipp==3.1.0               # via importlib-metadata
+zipp==3.4.1               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.1                 # via -r /home/vsts/work/1/s/work/requirements/pre.in, pip-tools

--- a/requirements/pre.macos.txt
+++ b/requirements/pre.macos.txt
@@ -4,30 +4,31 @@
 #
 #    python boots.py lock
 #
-bleach==3.1.5             # via readme-renderer
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
+bleach==3.3.0             # via readme-renderer
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
 click==7.1.2              # via pip-tools, romp
-docutils==0.16            # via readme-renderer
+docutils==0.17.1          # via readme-renderer
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via keyring, twine
-keyring==21.4.0           # via twine
-packaging==20.4           # via bleach
+importlib-metadata==4.0.0  # via keyring, twine
+keyring==23.0.1           # via twine
+packaging==20.9           # via bleach
 pip-tools==5.1.0          # via -r /Users/runner/work/1/s/work/requirements/pre.in
-pkginfo==1.5.0.1          # via twine
-pygments==2.6.1           # via readme-renderer
+pkginfo==1.7.0            # via twine
+pygments==2.8.1           # via readme-renderer
 pyparsing==2.4.7          # via packaging
-readme-renderer==26.0     # via twine
+readme-renderer==29.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.24.0          # via requests-toolbelt, romp, twine
+requests==2.25.1          # via requests-toolbelt, romp, twine
 romp==2020.3              # via -r /Users/runner/work/1/s/work/requirements/pre.in
-six==1.15.0               # via bleach, packaging, pip-tools, readme-renderer
-tqdm==4.48.2              # via twine
+six==1.15.0               # via bleach, pip-tools, readme-renderer
+tqdm==4.60.0              # via twine
 twine==3.1.1              # via -r /Users/runner/work/1/s/work/requirements/pre.in
-urllib3==1.25.10          # via requests
+typing-extensions==3.7.4.3  # via importlib-metadata
+urllib3==1.26.4           # via requests
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r /Users/runner/work/1/s/work/requirements/pre.in
-zipp==3.1.0               # via importlib-metadata
+zipp==3.4.1               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.1                 # via -r /Users/runner/work/1/s/work/requirements/pre.in, pip-tools

--- a/requirements/pre.windows.txt
+++ b/requirements/pre.windows.txt
@@ -4,31 +4,32 @@
 #
 #    python boots.py lock
 #
-bleach==3.1.5             # via readme-renderer
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
+bleach==3.3.0             # via readme-renderer
+certifi==2020.12.5        # via requests
+chardet==4.0.0            # via requests
 click==7.1.2              # via pip-tools, romp
-docutils==0.16            # via readme-renderer
+docutils==0.17.1          # via readme-renderer
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via keyring, twine
-keyring==21.4.0           # via twine
-packaging==20.4           # via bleach
+importlib-metadata==4.0.0  # via keyring, twine
+keyring==23.0.1           # via twine
+packaging==20.9           # via bleach
 pip-tools==5.1.0          # via -r D:\a\1\s\work\requirements\pre.in
-pkginfo==1.5.0.1          # via twine
-pygments==2.6.1           # via readme-renderer
+pkginfo==1.7.0            # via twine
+pygments==2.8.1           # via readme-renderer
 pyparsing==2.4.7          # via packaging
 pywin32-ctypes==0.2.0     # via keyring
-readme-renderer==26.0     # via twine
+readme-renderer==29.0     # via twine
 requests-toolbelt==0.9.1  # via twine
-requests==2.24.0          # via requests-toolbelt, romp, twine
+requests==2.25.1          # via requests-toolbelt, romp, twine
 romp==2020.3              # via -r D:\a\1\s\work\requirements\pre.in
-six==1.15.0               # via bleach, packaging, pip-tools, readme-renderer
-tqdm==4.48.2              # via twine
+six==1.15.0               # via bleach, pip-tools, readme-renderer
+tqdm==4.60.0              # via twine
 twine==3.1.1              # via -r D:\a\1\s\work\requirements\pre.in
-urllib3==1.25.10          # via requests
+typing-extensions==3.7.4.3  # via importlib-metadata
+urllib3==1.26.4           # via requests
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r D:\a\1\s\work\requirements\pre.in
-zipp==3.1.0               # via importlib-metadata
+zipp==3.4.1               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==20.1                 # via -r D:\a\1\s\work\requirements\pre.in, pip-tools

--- a/requirements/test.linux.txt
+++ b/requirements/test.linux.txt
@@ -4,68 +4,71 @@
 #
 #    python boots.py lock
 #
+--extra-index-url http://fstab.net/pypi/simple
+--trusted-host fstab.net
+
 -e git+https://github.com/epcpower/sunspec-demo@19581317ae2fd136b5df229d824f81a17da52c58#egg=epcsunspecdemo  # via -r /home/vsts/work/1/s/work/requirements/base.in, epyqlib
 -e file:sub/epyqlib#egg=epyqlib  # via -r /home/vsts/work/1/s/work/requirements/base.in
 -e git+https://github.com/altendky/pycparser@b19d2b7cb78bccc89ef187c1c4eb5db0fdd3bbf9#egg=pycparser  # via -r /home/vsts/work/1/s/work/requirements/base.in, cffi
 -e git+https://github.com/pyinstaller/PyInstaller@46286a1f455d8e0837f7c2b9e1bbdff1ef858f0f#egg=PyInstaller  # via -r /home/vsts/work/1/s/work/requirements/base.in
 -e git+https://github.com/altendky/pysunspec@f197baa9c373ff93b13bff22a1ca0368aa89b305#egg=pysunspec  # via -r /home/vsts/work/1/s/work/requirements/base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@0560511d0954c75cac43a47c685287ba93e01ba7#egg=pytest-twisted  # via -r /home/vsts/work/1/s/work/requirements/test.in
-alqtendpy==0.0.4          # via epyqlib
+alqtendpy==0.1.1          # via epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via pyinstaller
 appdirs==1.4.4            # via black, virtualenv
 argparse==1.4.0           # via codecov
-arrow==0.16.0             # via epyqlib
+arrow==1.0.3              # via epyqlib
 atomicwrites==1.4.0       # via pytest
 attrs==20.2.0             # via -r /home/vsts/work/1/s/work/requirements/base.in, alqtendpy, altendpy, automat, canmatrix, epcsunspecdemo, graham, pytest, twisted
 automat==20.2.0           # via twisted
-bitstruct==8.11.0         # via canmatrix, epyqlib
+bitstruct==8.11.1         # via canmatrix, epyqlib
 black==20.8b1             # via -r /home/vsts/work/1/s/work/requirements/test.in
-bleach==3.1.5             # via readme-renderer
+bleach==3.3.0             # via readme-renderer
 canmatrix==0.9.1          # via -r /home/vsts/work/1/s/work/requirements/base.in, epyqlib
-certifi==2020.6.20        # via requests
-cffi==1.14.2              # via cryptography, siphash-cffi
+certifi==2020.12.5        # via requests
+cffi==1.14.5              # via cryptography, siphash-cffi
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r /home/vsts/work/1/s/work/requirements/base.in, alqtendpy, black, canmatrix, epcsunspecdemo, epyqlib, pip-tools, romp
 codecov==2.0.5            # via -r /home/vsts/work/1/s/work/requirements/test.in
 constantly==15.1.0        # via twisted
-coverage==5.2.1           # via codecov, pytest-cov
-cryptography==3.1         # via secretstorage
-decorator==4.4.2          # via pytest-twisted
+coverage==5.5             # via codecov, pytest-cov
+cryptography==3.4.7       # via secretstorage
+decorator==5.0.7          # via pytest-twisted
 distlib==0.3.1            # via virtualenv
-docutils==0.16            # via readme-renderer
+docutils==0.17.1          # via readme-renderer
 et-xmlfile==1.0.1         # via openpyxl
 filelock==3.0.12          # via virtualenv
 future==0.18.2            # via canmatrix
-gitdb==4.0.5              # via gitpython
-gitpython==3.1.8          # via epyqlib
+gitdb==4.0.7              # via gitpython
+gitpython==3.1.14         # via epyqlib
 graham==0.1.11            # via -r /home/vsts/work/1/s/work/requirements/base.in, epyqlib
-greenlet==0.4.16          # via pytest-twisted
-hyperlink==20.0.1         # via twisted
+greenlet==1.0.0           # via pytest-twisted
+hyperlink==21.0.0         # via twisted
 idna==2.7                 # via hyperlink, requests
-importlib-metadata==1.7.0  # via keyring, pint, pluggy, twine, virtualenv
-incremental==17.5.0       # via twisted
+importlib-metadata==4.0.0  # via keyring, pint, pluggy, twine, virtualenv
+incremental==21.3.0       # via twisted
 jdcal==1.4.1              # via openpyxl
-jeepney==0.4.3            # via keyring, secretstorage
+jeepney==0.6.0            # via keyring, secretstorage
 jinja2==2.10.1            # via -r /home/vsts/work/1/s/work/requirements/base.in, altendpy
-keyring==21.4.0           # via twine
+keyring==23.0.1           # via twine
 lxml==4.3.0               # via -r /home/vsts/work/1/s/work/requirements/base.in, python-docx, xmldiff
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
-more-itertools==8.5.0     # via pytest
+more-itertools==8.7.0     # via pytest
 mypy-extensions==0.4.3    # via black
-natsort==7.0.1            # via epyqlib
+natsort==7.1.1            # via epyqlib
 openpyxl==2.5.12          # via -r /home/vsts/work/1/s/work/requirements/base.in
-packaging==20.4           # via bleach, pint
+packaging==20.9           # via bleach, pint
 pathlib2==2.3.5           # via canmatrix
-pathspec==0.8.0           # via black
-pint==0.15                # via epyqlib
+pathspec==0.8.1           # via black
+pint==0.17                # via epyqlib
 pip-tools==5.1.0          # via -r /home/vsts/work/1/s/work/requirements/pre.in
-pkginfo==1.5.0.1          # via twine
+pkginfo==1.7.0            # via twine
 pluggy==0.13.1            # via pytest, tox
-py==1.9.0                 # via pytest, tox
-pyelftools==0.26          # via epyqlib
-pygments==2.6.1           # via readme-renderer
+py==1.10.0                # via pytest, tox
+pyelftools==0.27          # via epyqlib
+pygments==2.8.1           # via readme-renderer
 pyhamcrest==2.0.2         # via twisted
 pyparsing==2.4.7          # via packaging
 pyqt5-sip==12.8.1         # via pyqt5
@@ -77,35 +80,35 @@ pytest==3.8.2             # via -r /home/vsts/work/1/s/work/requirements/test.in
 python-can==2.2.1         # via -r /home/vsts/work/1/s/work/requirements/test.in, epyqlib
 python-dateutil==2.8.1    # via arrow
 python-docx==0.8.10       # via epyqlib
-python-dotenv==0.14.0     # via epyqlib
+python-dotenv==0.17.0     # via epyqlib
 qt5reactor==0.5           # via -r /home/vsts/work/1/s/work/requirements/test.in, epyqlib
-qtawesome==0.7.2          # via epyqlib
+qtawesome==1.0.2          # via epyqlib
 qtpy==1.9.0               # via qtawesome
-readme-renderer==26.0     # via twine
-regex==2020.7.14          # via black
+readme-renderer==29.0     # via twine
+regex==2021.4.4           # via black
 requests-toolbelt==0.9.1  # via twine
 requests==2.20.0          # via -r /home/vsts/work/1/s/work/requirements/base.in, codecov, requests-toolbelt, romp, twine
 romp==2020.3              # via -r /home/vsts/work/1/s/work/requirements/pre.in
-secretstorage==3.1.2      # via keyring
+secretstorage==3.3.1      # via keyring
 siphash-cffi==0.1.4       # via epyqlib
-six==1.15.0               # via automat, bleach, cryptography, packaging, pathlib2, pip-tools, pytest, python-dateutil, qtawesome, readme-renderer, virtualenv, xmldiff
-smmap==3.0.4              # via gitdb
-toml==0.10.1              # via black
+six==1.15.0               # via automat, bleach, pathlib2, pip-tools, pytest, python-dateutil, readme-renderer, virtualenv, xmldiff
+smmap==4.0.0              # via gitdb
+toml==0.10.2              # via black
 toolz==0.9.0              # via -r /home/vsts/work/1/s/work/requirements/base.in, epcsunspecdemo
 tox==2.8.2                # via -r /home/vsts/work/1/s/work/requirements/base.in
-tqdm==4.48.2              # via epcsunspecdemo, twine
+tqdm==4.60.0              # via epcsunspecdemo, twine
 twine==3.1.1              # via -r /home/vsts/work/1/s/work/requirements/pre.in
 twisted==19.7.0           # via -r /home/vsts/work/1/s/work/requirements/test.in, epyqlib, qt5reactor
-typed-ast==1.4.1          # via black
-typing-extensions==3.7.4.3  # via black
+typed-ast==1.4.3          # via black
+typing-extensions==3.7.4.3  # via arrow, black, importlib-metadata
 urllib3==1.24.3           # via requests
-virtualenv==20.0.31       # via tox
+virtualenv==20.4.3        # via tox
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r /home/vsts/work/1/s/work/requirements/pre.in
 wrapt==1.12.1             # via python-can
 xmldiff==2.2              # via -r /home/vsts/work/1/s/work/requirements/base.in
-zipp==3.1.0               # via importlib-metadata
-zope.interface==5.1.0     # via twisted
+zipp==3.4.1               # via importlib-metadata
+zope.interface==5.4.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.macos.txt
+++ b/requirements/test.macos.txt
@@ -4,67 +4,70 @@
 #
 #    python boots.py lock
 #
+--extra-index-url http://fstab.net/pypi/simple
+--trusted-host fstab.net
+
 -e git+https://github.com/epcpower/sunspec-demo@19581317ae2fd136b5df229d824f81a17da52c58#egg=epcsunspecdemo  # via -r /Users/runner/work/1/s/work/requirements/base.in, epyqlib
 -e file:sub/epyqlib#egg=epyqlib  # via -r /Users/runner/work/1/s/work/requirements/base.in
 -e git+https://github.com/altendky/pycparser@b19d2b7cb78bccc89ef187c1c4eb5db0fdd3bbf9#egg=pycparser  # via -r /Users/runner/work/1/s/work/requirements/base.in, cffi
 -e git+https://github.com/pyinstaller/PyInstaller@46286a1f455d8e0837f7c2b9e1bbdff1ef858f0f#egg=PyInstaller  # via -r /Users/runner/work/1/s/work/requirements/base.in
 -e git+https://github.com/altendky/pysunspec@f197baa9c373ff93b13bff22a1ca0368aa89b305#egg=pysunspec  # via -r /Users/runner/work/1/s/work/requirements/base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@0560511d0954c75cac43a47c685287ba93e01ba7#egg=pytest-twisted  # via -r /Users/runner/work/1/s/work/requirements/test.in
-alqtendpy==0.0.4          # via epyqlib
+alqtendpy==0.1.1          # via epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via macholib, pyinstaller
 appdirs==1.4.4            # via black, virtualenv
 argparse==1.4.0           # via codecov
-arrow==0.16.0             # via epyqlib
+arrow==1.0.3              # via epyqlib
 atomicwrites==1.4.0       # via pytest
 attrs==20.2.0             # via -r /Users/runner/work/1/s/work/requirements/base.in, alqtendpy, altendpy, automat, canmatrix, epcsunspecdemo, graham, pytest, twisted
 automat==20.2.0           # via twisted
-bitstruct==8.11.0         # via canmatrix, epyqlib
+bitstruct==8.11.1         # via canmatrix, epyqlib
 black==20.8b1             # via -r /Users/runner/work/1/s/work/requirements/test.in
-bleach==3.1.5             # via readme-renderer
+bleach==3.3.0             # via readme-renderer
 canmatrix==0.9.1          # via -r /Users/runner/work/1/s/work/requirements/base.in, epyqlib
-certifi==2020.6.20        # via requests
-cffi==1.14.2              # via siphash-cffi
+certifi==2020.12.5        # via requests
+cffi==1.14.5              # via siphash-cffi
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r /Users/runner/work/1/s/work/requirements/base.in, alqtendpy, black, canmatrix, epcsunspecdemo, epyqlib, pip-tools, romp
 codecov==2.0.5            # via -r /Users/runner/work/1/s/work/requirements/test.in
 constantly==15.1.0        # via twisted
-coverage==5.2.1           # via codecov, pytest-cov
-decorator==4.4.2          # via pytest-twisted
+coverage==5.5             # via codecov, pytest-cov
+decorator==5.0.7          # via pytest-twisted
 distlib==0.3.1            # via virtualenv
-docutils==0.16            # via readme-renderer
+docutils==0.17.1          # via readme-renderer
 et-xmlfile==1.0.1         # via openpyxl
 filelock==3.0.12          # via virtualenv
 future==0.18.2            # via canmatrix
-gitdb==4.0.5              # via gitpython
-gitpython==3.1.8          # via epyqlib
+gitdb==4.0.7              # via gitpython
+gitpython==3.1.14         # via epyqlib
 graham==0.1.11            # via -r /Users/runner/work/1/s/work/requirements/base.in, epyqlib
-greenlet==0.4.16          # via pytest-twisted
-hyperlink==20.0.1         # via twisted
+greenlet==1.0.0           # via pytest-twisted
+hyperlink==21.0.0         # via twisted
 idna==2.7                 # via hyperlink, requests
-importlib-metadata==1.7.0  # via keyring, pint, pluggy, twine, virtualenv
-incremental==17.5.0       # via twisted
+importlib-metadata==4.0.0  # via keyring, pint, pluggy, twine, virtualenv
+incremental==21.3.0       # via twisted
 jdcal==1.4.1              # via openpyxl
 jinja2==2.10.1            # via -r /Users/runner/work/1/s/work/requirements/base.in, altendpy
-keyring==21.4.0           # via twine
+keyring==23.0.1           # via twine
 lxml==4.3.0               # via -r /Users/runner/work/1/s/work/requirements/base.in, python-docx, xmldiff
 macholib==1.14            # via pyinstaller
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
-more-itertools==8.5.0     # via pytest
+more-itertools==8.7.0     # via pytest
 mypy-extensions==0.4.3    # via black
-natsort==7.0.1            # via epyqlib
+natsort==7.1.1            # via epyqlib
 openpyxl==2.5.12          # via -r /Users/runner/work/1/s/work/requirements/base.in
-packaging==20.4           # via bleach, pint
+packaging==20.9           # via bleach, pint
 pathlib2==2.3.5           # via canmatrix
-pathspec==0.8.0           # via black
-pint==0.15                # via epyqlib
+pathspec==0.8.1           # via black
+pint==0.17                # via epyqlib
 pip-tools==5.1.0          # via -r /Users/runner/work/1/s/work/requirements/pre.in
-pkginfo==1.5.0.1          # via twine
+pkginfo==1.7.0            # via twine
 pluggy==0.13.1            # via pytest, tox
-py==1.9.0                 # via pytest, tox
-pyelftools==0.26          # via epyqlib
-pygments==2.6.1           # via readme-renderer
+py==1.10.0                # via pytest, tox
+pyelftools==0.27          # via epyqlib
+pygments==2.8.1           # via readme-renderer
 pyhamcrest==2.0.2         # via twisted
 pyparsing==2.4.7          # via packaging
 pyqt5-sip==12.8.1         # via pyqt5
@@ -76,34 +79,34 @@ pytest==3.8.2             # via -r /Users/runner/work/1/s/work/requirements/test
 python-can==2.2.1         # via -r /Users/runner/work/1/s/work/requirements/test.in, epyqlib
 python-dateutil==2.8.1    # via arrow
 python-docx==0.8.10       # via epyqlib
-python-dotenv==0.14.0     # via epyqlib
+python-dotenv==0.17.0     # via epyqlib
 qt5reactor==0.5           # via -r /Users/runner/work/1/s/work/requirements/test.in, epyqlib
-qtawesome==0.7.2          # via epyqlib
+qtawesome==1.0.2          # via epyqlib
 qtpy==1.9.0               # via qtawesome
-readme-renderer==26.0     # via twine
-regex==2020.7.14          # via black
+readme-renderer==29.0     # via twine
+regex==2021.4.4           # via black
 requests-toolbelt==0.9.1  # via twine
 requests==2.20.0          # via -r /Users/runner/work/1/s/work/requirements/base.in, codecov, requests-toolbelt, romp, twine
 romp==2020.3              # via -r /Users/runner/work/1/s/work/requirements/pre.in
 siphash-cffi==0.1.4       # via epyqlib
-six==1.15.0               # via automat, bleach, packaging, pathlib2, pip-tools, pytest, python-dateutil, qtawesome, readme-renderer, virtualenv, xmldiff
-smmap==3.0.4              # via gitdb
-toml==0.10.1              # via black
+six==1.15.0               # via automat, bleach, pathlib2, pip-tools, pytest, python-dateutil, readme-renderer, virtualenv, xmldiff
+smmap==4.0.0              # via gitdb
+toml==0.10.2              # via black
 toolz==0.9.0              # via -r /Users/runner/work/1/s/work/requirements/base.in, epcsunspecdemo
 tox==2.8.2                # via -r /Users/runner/work/1/s/work/requirements/base.in
-tqdm==4.48.2              # via epcsunspecdemo, twine
+tqdm==4.60.0              # via epcsunspecdemo, twine
 twine==3.1.1              # via -r /Users/runner/work/1/s/work/requirements/pre.in
 twisted==19.7.0           # via -r /Users/runner/work/1/s/work/requirements/test.in, epyqlib, qt5reactor
-typed-ast==1.4.1          # via black
-typing-extensions==3.7.4.3  # via black
+typed-ast==1.4.3          # via black
+typing-extensions==3.7.4.3  # via arrow, black, importlib-metadata
 urllib3==1.24.3           # via requests
-virtualenv==20.0.31       # via tox
+virtualenv==20.4.3        # via tox
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r /Users/runner/work/1/s/work/requirements/pre.in
 wrapt==1.12.1             # via python-can
 xmldiff==2.2              # via -r /Users/runner/work/1/s/work/requirements/base.in
-zipp==3.1.0               # via importlib-metadata
-zope.interface==5.1.0     # via twisted
+zipp==3.4.1               # via importlib-metadata
+zope.interface==5.4.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.windows.txt
+++ b/requirements/test.windows.txt
@@ -4,68 +4,71 @@
 #
 #    python boots.py lock
 #
+--extra-index-url http://fstab.net/pypi/simple
+--trusted-host fstab.net
+
 -e git+https://github.com/epcpower/sunspec-demo@19581317ae2fd136b5df229d824f81a17da52c58#egg=epcsunspecdemo  # via -r D:\a\1\s\work\requirements\base.in, epyqlib
 -e file:sub/epyqlib#egg=epyqlib  # via -r D:\a\1\s\work\requirements\base.in
 -e git+https://github.com/altendky/pycparser@b19d2b7cb78bccc89ef187c1c4eb5db0fdd3bbf9#egg=pycparser  # via -r D:\a\1\s\work\requirements\base.in, cffi
 -e git+https://github.com/pyinstaller/PyInstaller@46286a1f455d8e0837f7c2b9e1bbdff1ef858f0f#egg=PyInstaller  # via -r D:\a\1\s\work\requirements\base.in
 -e git+https://github.com/altendky/pysunspec@f197baa9c373ff93b13bff22a1ca0368aa89b305#egg=pysunspec  # via -r D:\a\1\s\work\requirements\base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@0560511d0954c75cac43a47c685287ba93e01ba7#egg=pytest-twisted  # via -r D:\a\1\s\work\requirements\test.in
-alqtendpy==0.0.4          # via epyqlib
+alqtendpy==0.1.1          # via epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via pyinstaller
 appdirs==1.4.4            # via black, virtualenv
 argparse==1.4.0           # via codecov
-arrow==0.16.0             # via epyqlib
+arrow==1.0.3              # via epyqlib
 atomicwrites==1.4.0       # via pytest
 attrs==20.2.0             # via -r D:\a\1\s\work\requirements\base.in, alqtendpy, altendpy, automat, canmatrix, epcsunspecdemo, graham, pytest, twisted
 automat==20.2.0           # via twisted
-bitstruct==8.11.0         # via canmatrix, epyqlib
+bitstruct==8.11.1         # via canmatrix, epyqlib
 black==20.8b1             # via -r D:\a\1\s\work\requirements\test.in
-bleach==3.1.5             # via readme-renderer
+bleach==3.3.0             # via readme-renderer
 canmatrix==0.9.1          # via -r D:\a\1\s\work\requirements\base.in, epyqlib
-certifi==2020.6.20        # via requests
-cffi==1.14.2              # via siphash-cffi
+certifi==2020.12.5        # via requests
+cffi==1.14.5              # via siphash-cffi
 chardet==3.0.4            # via requests
 click==7.1.2              # via -r D:\a\1\s\work\requirements\base.in, alqtendpy, black, canmatrix, epcsunspecdemo, epyqlib, pip-tools, romp
 codecov==2.0.5            # via -r D:\a\1\s\work\requirements\test.in
-colorama==0.4.3           # via pytest
+colorama==0.4.4           # via pytest
 constantly==15.1.0        # via twisted
-coverage==5.2.1           # via codecov, pytest-cov
-decorator==4.4.2          # via pytest-twisted
+coverage==5.5             # via codecov, pytest-cov
+decorator==5.0.7          # via pytest-twisted
 distlib==0.3.1            # via virtualenv
-docutils==0.16            # via readme-renderer
+docutils==0.17.1          # via readme-renderer
 et-xmlfile==1.0.1         # via openpyxl
 filelock==3.0.12          # via virtualenv
 future==0.18.2            # via canmatrix, pefile
-gitdb==4.0.5              # via gitpython
-gitpython==3.1.8          # via epyqlib
+gitdb==4.0.7              # via gitpython
+gitpython==3.1.14         # via epyqlib
 graham==0.1.11            # via -r D:\a\1\s\work\requirements\base.in, epyqlib
-greenlet==0.4.16          # via pytest-twisted
-hyperlink==20.0.1         # via twisted
+greenlet==1.0.0           # via pytest-twisted
+hyperlink==21.0.0         # via twisted
 idna==2.7                 # via hyperlink, requests
-importlib-metadata==1.7.0  # via keyring, pint, pluggy, twine, virtualenv
-incremental==17.5.0       # via twisted
+importlib-metadata==4.0.0  # via keyring, pint, pluggy, twine, virtualenv
+incremental==21.3.0       # via twisted
 jdcal==1.4.1              # via openpyxl
 jinja2==2.10.1            # via -r D:\a\1\s\work\requirements\base.in, altendpy
-keyring==21.4.0           # via twine
+keyring==23.0.1           # via twine
 lxml==4.3.0               # via -r D:\a\1\s\work\requirements\base.in, python-docx, xmldiff
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
-more-itertools==8.5.0     # via pytest
+more-itertools==8.7.0     # via pytest
 mypy-extensions==0.4.3    # via black
-natsort==7.0.1            # via epyqlib
+natsort==7.1.1            # via epyqlib
 openpyxl==2.5.12          # via -r D:\a\1\s\work\requirements\base.in
-packaging==20.4           # via bleach, pint
+packaging==20.9           # via bleach, pint
 pathlib2==2.3.5           # via canmatrix
-pathspec==0.8.0           # via black
+pathspec==0.8.1           # via black
 pefile==2019.4.18         # via pyinstaller
-pint==0.15                # via epyqlib
+pint==0.17                # via epyqlib
 pip-tools==5.1.0          # via -r D:\a\1\s\work\requirements\pre.in
-pkginfo==1.5.0.1          # via twine
+pkginfo==1.7.0            # via twine
 pluggy==0.13.1            # via pytest, tox
-py==1.9.0                 # via pytest, tox
-pyelftools==0.26          # via epyqlib
-pygments==2.6.1           # via readme-renderer
+py==1.10.0                # via pytest, tox
+pyelftools==0.27          # via epyqlib
+pygments==2.8.1           # via readme-renderer
 pyhamcrest==2.0.2         # via twisted
 pyparsing==2.4.7          # via packaging
 pyqt5-sip==12.8.1         # via pyqt5
@@ -77,35 +80,35 @@ pytest==3.8.2             # via -r D:\a\1\s\work\requirements\test.in, pytest-co
 python-can==2.2.1         # via -r D:\a\1\s\work\requirements\test.in, epyqlib
 python-dateutil==2.8.1    # via arrow
 python-docx==0.8.10       # via epyqlib
-python-dotenv==0.14.0     # via epyqlib
+python-dotenv==0.17.0     # via epyqlib
 pywin32-ctypes==0.2.0     # via keyring, pyinstaller
 qt5reactor==0.5           # via -r D:\a\1\s\work\requirements\test.in, epyqlib
-qtawesome==0.7.2          # via epyqlib
+qtawesome==1.0.2          # via epyqlib
 qtpy==1.9.0               # via qtawesome
-readme-renderer==26.0     # via twine
-regex==2020.7.14          # via black
+readme-renderer==29.0     # via twine
+regex==2021.4.4           # via black
 requests-toolbelt==0.9.1  # via twine
 requests==2.20.0          # via -r D:\a\1\s\work\requirements\base.in, codecov, requests-toolbelt, romp, twine
 romp==2020.3              # via -r D:\a\1\s\work\requirements\pre.in
 siphash-cffi==0.1.4       # via epyqlib
-six==1.15.0               # via automat, bleach, packaging, pathlib2, pip-tools, pytest, python-dateutil, qtawesome, readme-renderer, virtualenv, xmldiff
-smmap==3.0.4              # via gitdb
-toml==0.10.1              # via black
+six==1.15.0               # via automat, bleach, pathlib2, pip-tools, pytest, python-dateutil, readme-renderer, virtualenv, xmldiff
+smmap==4.0.0              # via gitdb
+toml==0.10.2              # via black
 toolz==0.9.0              # via -r D:\a\1\s\work\requirements\base.in, epcsunspecdemo
 tox==2.8.2                # via -r D:\a\1\s\work\requirements\base.in
-tqdm==4.48.2              # via epcsunspecdemo, twine
+tqdm==4.60.0              # via epcsunspecdemo, twine
 twine==3.1.1              # via -r D:\a\1\s\work\requirements\pre.in
 twisted==19.7.0           # via -r D:\a\1\s\work\requirements\test.in, epyqlib, qt5reactor
-typed-ast==1.4.1          # via black
-typing-extensions==3.7.4.3  # via black
+typed-ast==1.4.3          # via black
+typing-extensions==3.7.4.3  # via arrow, black, importlib-metadata
 urllib3==1.24.3           # via requests
-virtualenv==20.0.31       # via tox
+virtualenv==20.4.3        # via tox
 webencodings==0.5.1       # via bleach
 wheel==0.34.2             # via -r D:\a\1\s\work\requirements\pre.in
 wrapt==1.12.1             # via python-can
 xmldiff==2.2              # via -r D:\a\1\s\work\requirements\base.in
-zipp==3.1.0               # via importlib-metadata
-zope.interface==5.1.0     # via twisted
+zipp==3.4.1               # via importlib-metadata
+zope.interface==5.4.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
In order to run from source on a Windows setup, I needed to install "Build Tools for Visual Studio 2019" with the "C++ build tools" option. Update the `readme.rst` accordingly.