### PR TITLE
Feature/sc 869

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Changed
 
+- SC-869: Changed interface to support both sunspec1 and sunspec2 scaling factors
 - SC-683: Changed rejected callback handling to use automatically generated interface
 
 ### Removed

--- a/src/epcpm/parameterstointerface.py
+++ b/src/epcpm/parameterstointerface.py
@@ -667,6 +667,10 @@ class Parameter:
         sunspec_models: typing.Set,
         var_or_func: str,
     ) -> typing.List[str]:
+
+        scale_factor_variable = "NULL"
+        scale_factor_updater = "NULL"
+
         if sunspec_point is None:
             sunspec_variable = "NULL"
             sunspec_getter = "NULL"


### PR DESCRIPTION
## Jira Story
https://epcpower.atlassian.net/browse/SC-869

## About
Added support for sunspec2 scaling factors to generated code.
- Modified parameter item structures to contain pointer to scaling factor and updater function for both sunspec1 and sunspec2.
- Added two net scaler functions, itemNetScaleFactor1 and itemNetScaleFactor2, instead of one. First one uses corresponding sunspec1 data and second one uses sunspec2 data.
- Modified sunspec interface functions so that the correct net scaler function is used depending on which sunspec interface invokes the operation.

## Associated Pull Requests

*   https://github.com/epcpower/grid-tied/pull/342

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps

## Validation
