### PR TITLE
fix(SC-922), Fix setter function for array table element in group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Fixed
 
+- SC-922: Fix SIL array table element setter for groups
 - SC-654: Fix modbus bitfield interface generation.
 
 ### CI


### PR DESCRIPTION
## Jira Story
[SC-922](https://epcpower.atlassian.net/browse/SC-922)

## About
Fix setter function for array table element which is a child of group to call the setter function with correct number of parameters in SIL.

Previously for grid support tables, the *setNumActivePoints function was called with only 1 parameter but the function takes 4. The first parameter is the selected grid support curve but the function was called with num active points in its place and it would cause overindexing if the number of active points was larger than 3.

Code generation diff
![image](https://user-images.githubusercontent.com/20504548/215689698-b193fc0e-e9a9-40e0-ad29-02f8ccbf57ed.png)

## Associated Pull Requests

*   [https://github.com/epcpower/grid-tied/pull/374 ] _
*   [ ] _

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps

## Validation


[SC-922]: https://epcpower.atlassian.net/browse/SC-922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ