### PR TITLE
feat (SC-935): sunspec2 start address 40k for spreadsheet output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Changed
 
+- SC-935: SunSpec2 start address 40k for spreadsheet output
 - SC-805: No longer output dummy SunSpec1 models in user spreadsheet
 - SC-869: Changed interface to support both sunspec1 and sunspec2 scaling factors
 - SC-683: Changed rejected callback handling to use automatically generated interface

--- a/src/epcpm/pm_helper.py
+++ b/src/epcpm/pm_helper.py
@@ -20,6 +20,13 @@ class SunSpecSection(Enum):
 SUNS_LENGTH = 2
 
 
+# Define the start address for each SunSpec address space.
+SUNSPEC_START_ADDRESS = {
+    SunSpecSection.SUNSPEC_ONE: 0,
+    SunSpecSection.SUNSPEC_TWO: 40000,
+}
+
+
 def convert_uuid_to_variable_name(input_uuid: uuid.UUID) -> str:
     """
     Replace the dashes in a given UUID with underscores. Return a string value.
@@ -155,3 +162,21 @@ def get_sunspec_starting_register_values(
         return "0x5375", "0x6e53"
     else:
         return "0xffff", "0xffff"
+
+
+def calculate_start_address(sunspec_id: SunSpecSection) -> int:
+    """
+    Calculate the start address given the SunSpec section ID.
+
+    Args:
+        sunspec_id: SunSpec section internal identifier
+
+    Returns:
+        start address
+    """
+    # Calculate the start address
+    start_address = SUNSPEC_START_ADDRESS[sunspec_id]
+    # Account for 'SunS' length.
+    start_address += SUNS_LENGTH
+
+    return start_address

--- a/src/epcpm/sunspectocsv.py
+++ b/src/epcpm/sunspectocsv.py
@@ -150,8 +150,9 @@ class Root:
         else:
             children = list(self.wrapped.children)
 
-        # Account for 'SunS' length.
-        model_offset = epcpm.pm_helper.SUNS_LENGTH
+        # Calculate the start address
+        model_offset = epcpm.pm_helper.calculate_start_address(self.sunspec_id)
+
         for model in children:
             if isinstance(model, epcpm.sunspecmodel.Table):
                 # TODO: for now, implement it soon...

--- a/src/epcpm/sunspectoxlsx.py
+++ b/src/epcpm/sunspectoxlsx.py
@@ -172,8 +172,9 @@ class Root:
             else:
                 children = list(self.wrapped.children)
 
-            # Account for 'SunS' length.
-            model_offset = epcpm.pm_helper.SUNS_LENGTH
+            # Calculate the start address
+            model_offset = epcpm.pm_helper.calculate_start_address(self.sunspec_id)
+
             for model in children:
                 if isinstance(model, epcpm.sunspecmodel.Table):
                     # TODO: for now, implement it soon...


### PR DESCRIPTION
## Jira Story

[SC-935](https://epcpower.atlassian.net/browse/SC-935)

## About

Spreadsheet output should use start address of 40k for SunSpec2 modbus addresses.

See grid-tied PR for details.

## Associated Pull Requests

*   [ ] [grid-tied](https://github.com/epcpower/grid-tied/pull/376)

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps



## Validation



[SC-935]: https://epcpower.atlassian.net/browse/SC-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ