### PR TITLE
fix (SC-995): update ci.yml actions to alleviate warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
     name: CI
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -85,7 +85,7 @@ jobs:
         run: |
           poetry publish --repository epc-power
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pm
           path: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,5 +29,6 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### CI
 
+- SC-995: Update actions versions to alleviate CI build warnings
 - SC-760: Pin poetry to 1.1.15
 - SC-401: Romp Removal / Poetry Implementation


### PR DESCRIPTION
## Jira Story

SC-995

## About
![image](https://user-images.githubusercontent.com/77705928/221330023-3bae9463-efbc-4660-b84e-18cf7d4766f1.png)

1. actions/checkout@v2 -> actions/checkout@v3
2. actions/setup-python@v2 -> actions/setup-python@v4
3. aws-actions/configure-aws-credentials@v1 -> aws-actions/configure-aws-credentials@v1-node16
4. actions/upload-artifact@v2 -> actions/upload-artifact@v3

## Associated Pull Requests

N/A

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps

## Validation

CI completes successfully without any warnings.
