### PR TITLE
feat(MDL-378): Add parameter name, group and getter function to SIL p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Added
 
+- MDL-378: Add parameter name, group and getter function to SIL parameter generation
 - SC-835: SunSpec2 table support
 - SC-795: Add units to SunSpec2/parameters for 700 series models
 - SC-754: Add SunSpec 700 series models to SunSpec2


### PR DESCRIPTION
## Jira Story
https://epcpower.atlassian.net/jira/software/c/projects/MDL/boards/50?modal=detail&selectedIssue=MDL-378

## About
Add parameter name, group and getter function to SIL parameter generation


- Name is not really used because EPyQ displays the name with the CAN_mux name but it is helpful for debugging the code generation that the created parameters have a field for name that can be used to identify it.
- Add path/group so that the parameters can be displayed in same tree structure as in EPyQ
- Add getter so that SIL can read the parameters same way as EPyQ

## Associated Pull Requests

*   [ ] https://github.com/epcpower/grid-tied/pull/432
*   [ ] https://github.com/epcpower/embedded-library/pull/282

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps

## Validation
