### PR TITLE
fix (SC-1195): bitfield SunSpec2 interface generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Fixed
 
+- SC-1195: Fix SunSpec2 bitfield interface generation
 - SC-910: Fix SunSpec2 table parameter interface generation.
 - SC-922: Fix SIL array table element setter for groups
 - SC-654: Fix modbus bitfield interface generation.

--- a/src/epcpm/parameterstobitfieldsc.py
+++ b/src/epcpm/parameterstobitfieldsc.py
@@ -227,7 +227,11 @@ class Root:
                     members_interface_c_lines.extend(
                         builder.gen_bitfield_members_interface()
                     )
-                    members_info_c_lines.extend(builder.gen_members_interface())
+                    members_info_c_lines.extend(
+                        builder.gen_members_interface(
+                            epcpm.pm_helper.SunSpecSection.SUNSPEC_ONE
+                        )
+                    )
                 else:
                     common_c_lines.extend(
                         DataPointBitfield.gen_default_common_interface(
@@ -235,7 +239,9 @@ class Root:
                         )
                     )
                     members_info_c_lines.extend(
-                        DataPointBitfield.gen_default_members_interface()
+                        DataPointBitfield.gen_default_members_interface(
+                            epcpm.pm_helper.SunSpecSection.SUNSPEC_ONE
+                        )
                     )
 
                 if "sunspec2" in modbus_nodes:
@@ -251,7 +257,11 @@ class Root:
                     members_interface_c_lines.extend(
                         builder.gen_bitfield_members_interface()
                     )
-                    members_info_c_lines.extend(builder.gen_members_interface())
+                    members_info_c_lines.extend(
+                        builder.gen_members_interface(
+                            epcpm.pm_helper.SunSpecSection.SUNSPEC_TWO
+                        )
+                    )
                 else:
                     common_c_lines.extend(
                         DataPointBitfield.gen_default_common_interface(
@@ -259,7 +269,9 @@ class Root:
                         )
                     )
                     members_info_c_lines.extend(
-                        DataPointBitfield.gen_default_members_interface()
+                        DataPointBitfield.gen_default_members_interface(
+                            epcpm.pm_helper.SunSpecSection.SUNSPEC_TWO
+                        )
                     )
 
                 # Generate C lines for static modbus node
@@ -585,9 +597,14 @@ class DataPointBitfield:
             "",
         ]
 
-    def gen_members_interface(self) -> typing.List[str]:
+    def gen_members_interface(
+        self, sunspec_id: epcpm.pm_helper.SunSpecSection
+    ) -> typing.List[str]:
         """
         Generate the SunSpec bitfield member additional definitions.
+
+        Args:
+            sunspec_id: SunSpec section internal identifier
 
         Returns:
             list: bitfield member additional definitions
@@ -599,19 +616,24 @@ class DataPointBitfield:
         array_name = f"sunspecBitfieldItems_{name_uuid}"
 
         return [
-            f".sunspecMembers = {array_name},",
-            f".sunspecMembersCount = {len(members)},",
+            f".sunspec{sunspec_id.value}Members = {array_name},",
+            f".sunspec{sunspec_id.value}MembersCount = {len(members)},",
         ]
 
     @staticmethod
-    def gen_default_members_interface() -> typing.List[str]:
+    def gen_default_members_interface(
+        sunspec_id: epcpm.pm_helper.SunSpecSection,
+    ) -> typing.List[str]:
         """
         Generate a default (empty) SunSpec bitfield members definitions for the interface item.
+
+        Args:
+            sunspec_id: SunSpec section internal identifier
 
         Returns:
             list: default bitfield member definitions
         """
         return [
-            ".sunspecMembers = NULL,",
-            ".sunspecMembersCount = 0,",
+            f".sunspec{sunspec_id.value}Members = NULL,",
+            f".sunspec{sunspec_id.value}MembersCount = 0,",
         ]


### PR DESCRIPTION
## Jira Story

[SC-1195](https://epcpower.atlassian.net/browse/SC-1195)

## About

Modbus register 3214 only reads as 0. Status is unable to change.

## Associated Pull Requests

*   [ ] grid-tied

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps

## Validation


[SC-1195]: https://epcpower.atlassian.net/browse/SC-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ