### PR TITLE
fix (SC-1413): EPC-CAN.xlsx enumerator list output now uses can.json as source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Fixed
 
+- SC-1413: EPC-CAN.xlsx enumerator list output now uses can.json as source
 - SC-1195: Fix SunSpec2 bitfield interface generation
 - SC-910: Fix SunSpec2 table parameter interface generation.
 - SC-922: Fix SIL array table element setter for groups

--- a/src/epcpm/cantoxlsx.py
+++ b/src/epcpm/cantoxlsx.py
@@ -260,7 +260,9 @@ class Signal:
                     row.maximum = parameter.maximum
 
                 if self.wrapped.enumeration_uuid is not None:
-                    enumeration = self.parameter_uuid_finder(self.wrapped.enumeration_uuid)
+                    enumeration = self.parameter_uuid_finder(
+                        self.wrapped.enumeration_uuid
+                    )
                     child_enum_list = []
                     for child_enum in enumeration.children:
                         child_enum_list.append(

--- a/src/epcpm/cantoxlsx.py
+++ b/src/epcpm/cantoxlsx.py
@@ -280,7 +280,7 @@ class Signal:
                 # Chop off the parameter query prefix to match what is seen in the EPyQ parameters tab.
                 can_parameter_path = can_parameter_path[len(PARAMETER_QUERY_PREFIX) :]
                 # Replace '->' with nothing to match EPyQ name. This is for table parameters.
-                can_parameter_path = can_parameter_path.replace("->", "")
+                can_parameter_path = can_parameter_path.replace(" -> ", "")
             row.epyq_can_parameter_name = f"{can_parameter_path}:{self.wrapped.name}"
 
             return [row]

--- a/src/epcpm/cantoxlsx.py
+++ b/src/epcpm/cantoxlsx.py
@@ -259,8 +259,8 @@ class Signal:
                 if parameter.maximum is not None:
                     row.maximum = parameter.maximum
 
-                if parameter.enumeration_uuid is not None:
-                    enumeration = self.parameter_uuid_finder(parameter.enumeration_uuid)
+                if self.wrapped.enumeration_uuid is not None:
+                    enumeration = self.parameter_uuid_finder(self.wrapped.enumeration_uuid)
                     child_enum_list = []
                     for child_enum in enumeration.children:
                         child_enum_list.append(


### PR DESCRIPTION
## Jira Story

[SC-1413](https://epcpower.atlassian.net/browse/SC-1413)

## About

## Associated Pull Requests

*   [ ] grid-tied

## Update Changelog

*   [x] Changelog updated

## Reproduction Steps

## Validation


[SC-1413]: https://epcpower.atlassian.net/browse/SC-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ