### PR TITLE
feat(SC-1429, sunspec): Add possibility to configure identifier regis…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For instructions, see the [changelog confluence page](https://epcpower.atlassian
 
 ### Added
 
+- SC-1429: Add support for dynamic sunspec1/sunspec2 identifier configuration
 - MDL-378: Add parameter name, group and getter function to SIL parameter generation
 - SC-835: SunSpec2 table support
 - SC-795: Add units to SunSpec2/parameters for 700 series models

--- a/src/epcpm/sunspectointerface.py
+++ b/src/epcpm/sunspectointerface.py
@@ -394,6 +394,9 @@ class Root:
         h_lines.extend(
             f"extern ModbusReg * const sunspec{self.sunspec_id.value}AddrRegMap[{total_addresses}];\n"
         )
+        h_lines.extend(
+            f"\nvoid sunspec{self.sunspec_id.value}SetIdentifier(uint16_t id_hi, uint16_t id_lo);\n"
+        )
 
         h_lines.extend([f"\n#endif //{include_guard}\n"])
 
@@ -586,6 +589,16 @@ class Root:
         c_lines.extend(
             [
                 "};\n\n",
+            ]
+        )
+
+        c_lines.extend(
+            [
+                f"void sunspec{self.sunspec_id.value}SetIdentifier(uint16_t id_hi, uint16_t id_lo) ",
+                "{\n",
+                f"    sunspec{self.sunspec_id.value}Interface.SunS_ID_hi = id_hi;\n",
+                f"    sunspec{self.sunspec_id.value}Interface.SunS_ID_lo = id_lo;\n",
+                "}\n",
             ]
         )
 


### PR DESCRIPTION
## Jira Story
https://epcpower.atlassian.net/browse/SC-1429

## About
Added possibility to configure sunspec1 and sunspec2 interface identifier registers dynamically.

## Associated Pull Requests
* https://github.com/epcpower/embedded-library/pull/372
* https://github.com/epcpower/grid-tied/pull/564

## Update Changelog
*   [ x] Changelog updated

## Validation
Validation results are presented in the corresponding gridtied PR.
