### PR TITLE
bugfix(SC-2407):handle case for all zero defaults

### DIFF
--- a/src/epcpm/cantoxlsx.py
+++ b/src/epcpm/cantoxlsx.py
@@ -496,17 +496,11 @@ def format_for_manual(
         parameter_name_out = row[9].value
         minimum_out = row[10].value
         maximum_out = row[11].value
-        defaults_out = []
-        for col in row[12:]:
-            if col.value:
-                defaults_out.append(f"{col.value}")
-            else:
-                defaults_out.append("")
 
         # Initialize product specific default values, copying from the filtered rows.
         psd_values_all = []
         for col in row[12:]:
-            if col.value:
+            if col.value is not None:
                 psd_values_all.append(f"{col.value}")
             else:
                 psd_values_all.append("")

--- a/src/epcpm/cantoxlsx.py
+++ b/src/epcpm/cantoxlsx.py
@@ -28,7 +28,8 @@ TABLES_TREE_STR = f"{TABLES_STR}{PATH_SEPARATOR}Tree"
 FILTER_GROUPS = [
     "2. DC",
     "9. Simulation Mode",
-    "A. ABB",
+    "A. ABB",  # Legacy, now it is "Hitachi Energy"
+    "A. Hitachi Energy",
     "B. Other -> Authorization",
     "B. Other -> Debug",
 ]


### PR DESCRIPTION
## Jira Story

[SC-2407](https://epcpower.atlassian.net/browse/SC-2407)

## About

Fix automated controls manual output when defaults are all zero.

Also filter out "A. <new_co_name>" which used to be "A. <old_co_name>".

## Associated Pull Requests

* [ ] _
* [ ] _

## Reproduction Steps

## Validation


[SC-2407]: https://epcpower.atlassian.net/browse/SC-2407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ