### PR TITLE
fix(SC-2910): Updated the size of void pointer in the interface

### DIFF
--- a/src/epcpm/parameterstointerface.py
+++ b/src/epcpm/parameterstointerface.py
@@ -856,7 +856,7 @@ class VoidPointerType:
     name = attr.ib(default="void_p")
     type = attr.ib(default="void*")
     minimum_code = attr.ib(default="((void *) 0)")
-    maximum_code = attr.ib(default="((void *) UINT32_C(0x240000))")
+    maximum_code = attr.ib(default="((void *) UINT32_C(0x400000))")
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
Updated the size of the void pointer type in the interface to be able to parameterize datalogger addresses that lie outside of the current maximum limit of 0x240000

## Jira Story
https://epcpower.atlassian.net/browse/SC-2910
## About

## Associated Pull Requests

* [ ] _
* [ ] _

## Reproduction Steps

## Validation
Parameter range after the change
![image](https://github.com/user-attachments/assets/0f0835e9-6d7a-4b49-aaa6-20c8494c474e)

Toggled the flag `DtmLemData:Unlocked` and monitored the internal variable in the datalogger 

![image](https://github.com/user-attachments/assets/911a30a1-bf06-43b2-93c3-1591b84c155a)

![image](https://github.com/user-attachments/assets/d12af9a9-6375-42bc-975c-4d661cbee9fb)

