### PR TITLE
ci(SC-5421): bump pinned GitHub Actions to Node.js 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,16 @@ jobs:
     name: CI
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -90,7 +90,7 @@ jobs:
         run: |
           poetry publish --repository epc-power
       - name: Archive artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pm
           path: |


### PR DESCRIPTION
## Summary
- Upgrades the four pinned actions in `.github/workflows/ci.yml` to their current Node.js 24 majors to clear the Node.js 20 deprecation warnings GitHub now emits.
- `actions/checkout` v4 → v6, `actions/setup-python` v5 → v6, `aws-actions/configure-aws-credentials` v4 → v6, `actions/upload-artifact` v4 → v7.
- All inputs we use (`fetch-depth`, `ref`, `submodules`, `python-version`, AWS credential/region inputs, `name`, `path`) are supported unchanged in the new majors. The Node 24 majors require Actions Runner ≥ v2.327.1, which GitHub-hosted `windows-2022` already satisfies.

Jira: [SC-5421](https://epcpower.atlassian.net/browse/SC-5421)

## Test plan
- [ ] CI runs on this branch with no Node.js deprecation warnings in the workflow log.
- [ ] `pm` artifact uploads and downloads correctly (upload-artifact v7 only changes default behavior when `archive: false` is set, which we don't use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SC-5421]: https://epcpower.atlassian.net/browse/SC-5421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ